### PR TITLE
update jsonist

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/ryanramage/ndjson-to-elasticsearch",
   "dependencies": {
     "async": "^2.0.0-rc.1",
-    "jsonist": "^1.3.0",
+    "jsonist": "^3.0.1",
     "lodash.template": "^4.2.0",
     "ndjson": "^1.3.0",
     "rc": "^1.0.3",


### PR DESCRIPTION
mostly to get rid of TimeoutOverflowWarning errors in Node >= v12
[occuring in `hyperquest`](https://github.com/substack/hyperquest/issues/62) (until fixed in `hyperquest v2.1.3`), a dependency of `jsonist` (which got updated to `hyperquest v2.1.3` in `jsonist v2.1.1`, but updating to the latest version doesn't seem to be a probem)

Once (and if) this PR is validated and a patch version is published, another PR will follow in [`couch2elastic4sync`](https://github.com/ryanramage/couch2elastic4sync) to update `ndjson-to-elasticsearch`, `jsonist`, and `hyperquest` for the same reason